### PR TITLE
Main delimiter

### DIFF
--- a/src/clojask_io/delimiter.clj
+++ b/src/clojask_io/delimiter.clj
@@ -1,6 +1,7 @@
-(create-ns 'clojask-io.delimiter)
+(ns clojask-io.delimiter)
 
-(require '[clojure.string :as str])
+(require '[clojure.string :as str]
+         '[clojure.java.io])
 
 (defn get-one-string
   [vector-of-str, str-len, start-pos]
@@ -36,6 +37,9 @@
             (def quote-flag true)
             (def result-vec (conj result-vec item)))))))
   result-vec)
+;; => Syntax error compiling at (c:\Users\Hicco\Desktop\clojask-io\src\clojask_io\delimiter.clj:28:16).
+;;    No such namespace: str
+
 
 (defn my-frequencies
   [string-of-a-row,max-len]
@@ -48,7 +52,7 @@
    (if (= s1 {})
      (def result s2)
      (doseq [item (keys s1)]
-       (if (and (contains? s2 item) (= (get s1 item) (get s2 item)))
+       (when (and (contains? s2 item) (= (get s1 item) (get s2 item)))
          (def result (assoc result item (get s1 item))))))
    result))
 
@@ -57,7 +61,7 @@
     true
     false))
 
-(defn reduce-candidates "" [map-of-candidates,string-of-a-row]
+(defn reduce-candidates  [map-of-candidates,string-of-a-row]
   (def updated  map-of-candidates)
   (doseq [x (keys updated)
           y (keys updated)]
@@ -66,30 +70,34 @@
       (def updated (dissoc updated y))))
   updated)
 
-(defn get-delimiter
+(defn get-delimiter-main
   "reads in specified number of lines  and stores frequencies of each line in a vector"
   ([name,max-len]
    (with-open [rdr (clojure.java.io/reader name)]
-
      (loop [count_ 0 curr  {}  result {}  temp-seq (line-seq rdr)]
-       (if (or (= temp-seq ())  (= 1 (count result)) (= 1000 count_))
-         (do
+       (if (or (= temp-seq ())  (= 1 (count result)) (= 1000 count_)) 
            (if (= 1 (count result)) (first (keys result))
                (do
                  (println "warning: there are multiple potential delimiters, and the one with most occurrences have been returned")
-                 (first (last (sort-by second result))))))
-         (do
-           (recur (inc count_) (my-frequencies (first temp-seq) max-len)  (reduce-candidates (intersection result curr) (first (line-seq rdr))) (drop 1 temp-seq)))))))
+                 (first (last (sort-by second result))))) 
+           (recur (inc count_) (my-frequencies (first temp-seq) max-len)  (reduce-candidates (intersection result curr) (first (line-seq rdr))) (drop 1 temp-seq))))))
   ([name]
    (with-open [rdr (clojure.java.io/reader name)]
-
      (loop [count_ 0 curr  {}  result {}  temp-seq (line-seq rdr)]
-       (if (or (= temp-seq ())  (= 1 (count result)) (= 3000 count_))
-         (do
+       (if (or (= temp-seq ())  (= 1 (count result)) (= 3000 count_)) 
            (if (= 1 (count result)) (first (keys result))
                (do
-                 (println "warning: there are multiple potential delimiters, and the one with most occurrences have been returned")
-                 (first (last (sort-by second result))))))
-         (do
-           (recur (inc count_) (my-frequencies (first temp-seq) 3)  (reduce-candidates (intersection result curr) (first (line-seq rdr))) (drop 1 temp-seq))))))))
+                 (println "warning: there are multiple potential delimiters, and the with most occurrences have been returned")
+                 (first (last (sort-by second result))))) 
+           (recur (inc count_) (my-frequencies (first temp-seq) 3)  (reduce-candidates (intersection result curr) (first (line-seq rdr))) (drop 1 temp-seq)))))))
 
+(defn get-delimiter
+  ([name,max-len]
+   (try
+     (get-delimiter-main name max-len)
+     (catch Exception e (println (str "caught exception: " (.getMessage e))))))
+  ([name]
+   (try
+     (get-delimiter-main name)
+     (catch Exception e (println (str "caught exception: " (.getMessage e))))))
+   )

--- a/src/clojask_io/delimiter.clj
+++ b/src/clojask_io/delimiter.clj
@@ -37,8 +37,7 @@
             (def quote-flag true)
             (def result-vec (conj result-vec item)))))))
   result-vec)
-;; => Syntax error compiling at (c:\Users\Hicco\Desktop\clojask-io\src\clojask_io\delimiter.clj:28:16).
-;;    No such namespace: str
+
 
 
 (defn my-frequencies

--- a/src/clojask_io/delimiter.clj
+++ b/src/clojask_io/delimiter.clj
@@ -3,6 +3,19 @@
 (require '[clojure.string :as str]
          '[clojure.java.io])
 
+
+(defn format-delimiter
+  [delimiter]
+  (def result [])
+  (doseq [character (str/split delimiter #"")]
+    (def result (conj result (str "[" character "]" ))))
+  (re-pattern (str/join result)))
+
+;;this function is for formatting delimiters from string into regular expressions to be passed into str/split
+;;eg. (format-delimiter "@!?") will return "[@][!][?]"
+;;this can avoid characters in delimiters such as *, ?, etc. to be interpreted as re symbols, eg.(? as zero or one occurrence of the previous character)
+;;eg. (str/split "123@!?456" #"[@][!][?]") returns ["123" "456"], but (str/split "123@!?456" #"@!?") returns ["123" "?456"]
+
 (defn get-one-string
   [vector-of-str, str-len, start-pos]
   (loop [len-count 0 result [] curr-pos start-pos]

--- a/src/clojask_io/input.clj
+++ b/src/clojask_io/input.clj
@@ -60,7 +60,7 @@
   "Lazily read a dataset file (csv, txt, dat, tsv, tab) into a vector of vectors"
   [path & {:keys [sep format stat wrap output] :or {sep nil format nil stat false wrap nil output false}}]
   (let [format (or format (infer-format path))
-        sep (or (clojure-io.delimiter/get-delimiter path) sep (get format-sep-map format) ",")]
+        sep (or (clojask-io.delimiter/get-delimiter path) sep (get format-sep-map format) ",")]
     (if (.contains ["piquet" "dta"] format)
       ;; not supported type
       (do

--- a/src/clojask_io/input.clj
+++ b/src/clojask_io/input.clj
@@ -60,7 +60,7 @@
   "Lazily read a dataset file (csv, txt, dat, tsv, tab) into a vector of vectors"
   [path & {:keys [sep format stat wrap output] :or {sep nil format nil stat false wrap nil output false}}]
   (let [format (or format (infer-format path))
-        sep (or (clojask-io.delimiter/get-delimiter path) sep (get format-sep-map format) ",")]
+        sep (sep or (clojask-io.delimiter/get-delimiter path) (get format-sep-map format) ",")]
     (if (.contains ["piquet" "dta"] format)
       ;; not supported type
       (do

--- a/src/clojask_io/input.clj
+++ b/src/clojask_io/input.clj
@@ -5,6 +5,7 @@
             [jdk.net.URLConnection :refer [get-content-length]]
             [clojask-io.output :refer :all]
             [clojask-io.core :refer :all]
+            [clojask-io.delimiter]
             [dk.ative.docjure.spreadsheet :as excel]))
 
 
@@ -59,7 +60,7 @@
   "Lazily read a dataset file (csv, txt, dat, tsv, tab) into a vector of vectors"
   [path & {:keys [sep format stat wrap output] :or {sep nil format nil stat false wrap nil output false}}]
   (let [format (or format (infer-format path))
-        sep (or sep (get format-sep-map format) ",")]
+        sep (or (clojure-io.delimiter/get-delimiter path) sep (get format-sep-map format) ",")]
     (if (.contains ["piquet" "dta"] format)
       ;; not supported type
       (do

--- a/src/clojask_io/input.clj
+++ b/src/clojask_io/input.clj
@@ -27,7 +27,7 @@
 (defn csv-local
   "read in a local csv dataset"
   [path & {:keys [sep stat wrap] :or {sep #"," stat false wrap nil}}]
-  (let [sep (if (string? sep) (re-pattern sep) sep)
+  (let [sep (if (string? sep) (clojask-io.delimiter/format-delimiter sep) sep)  
         reader (io/reader path)
         data (line-seq reader)
         data (map #(str/split % sep -1) data)
@@ -60,7 +60,7 @@
   "Lazily read a dataset file (csv, txt, dat, tsv, tab) into a vector of vectors"
   [path & {:keys [sep format stat wrap output] :or {sep nil format nil stat false wrap nil output false}}]
   (let [format (or format (infer-format path))
-        sep (sep or (clojask-io.delimiter/get-delimiter path) (get format-sep-map format) ",")]
+        sep (or sep (clojask-io.delimiter/get-delimiter path) (get format-sep-map format) ",")]
     (if (.contains ["piquet" "dta"] format)
       ;; not supported type
       (do


### PR DESCRIPTION
Added helper function to format delimiters to be passed into str/split(previously there could be problems if delimiters contain re symbols like * and ? ), see delimiter.clj for more infomation. Fixed the wrong order between sep and or in input.clj